### PR TITLE
Localisation fix

### DIFF
--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -1,0 +1,20 @@
+nl:
+  Level51\Cloudinary\Cloudinary:
+    CLOUD_NAME: Cloud Name
+    CTA_DELETE: Delete
+    CTA_SHOW: Bekijk
+    CTA_REMOVE: Verwijder
+    CTA_UPLOAD: Upload
+    CTA_UPLOAD_REPLACE: Nieuwe upload
+    DESTINATION_FOLDER: Bestemmingsmap
+    ERR_DOWNLOAD_NO_PUBLIC_ID: 'De Cloudinary afbeelding {ImageID} heeft geen "public_id"'
+    ERR_INVALID_FILE_CATEGORY: 'Deze bestandscategorie is niet geldig. Geldige waarden zijn "image" of "image/supported".'
+    READ_ONLY_NO_IMAGE: Geen afbeelding
+    FILENAME: Naam
+    PUBLIC_ID: Public ID
+    SIZE: Grootte
+    WIDTH: Breedte
+    HEIGHT: Hoogte
+    FORMAT: Formaat
+    CLOUDINARY_INFO: Cloudinary Info
+    ERR_MISSING_UPLOAD_PRESET: '"Level51\Cloudinary\Cloudinary.upload_preset" config is een verplicht veld'

--- a/src/UploadField.php
+++ b/src/UploadField.php
@@ -124,7 +124,7 @@ class UploadField extends FormField implements FileHandleField {
         ];
 
         foreach ($keys as $key) {
-            $payload[$key] = _t('Level51\Cloudinary\Cloudinary.' . $key);
+            $payload[$key] = _t('Level51\Cloudinary\Cloudinary.' . $key, " ");
         }
 
         return $payload;


### PR DESCRIPTION
Hi all! Thanks for this module. Saved me a lot of work! Here is a pull-request for a minor issue, but it's wrecking havoc in our CMS since it's causing user warnings: [User Warning] Missing default for localisation key. The problem is caused by a missing default when declaring the _t(...) fields. An empty default (needs to be at least one space) will suffice, since all lang.yml files are present. Also added a Dutch lang file ;-) 